### PR TITLE
adding basic sigscanner

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,7 +91,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 RawStringFormats: 
-ReflowComments:  true
+ReflowComments:  false
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/helveta/initializer.hh
+++ b/helveta/initializer.hh
@@ -25,6 +25,7 @@ constexpr float PI = 3.141593f;
 #include <optional>
 #include <vector>
 #include <stdexcept>
+#include <functional>
 
 // config
 #include "config.hh"

--- a/helveta/memory/pointer.hh
+++ b/helveta/memory/pointer.hh
@@ -196,7 +196,7 @@ public:
   }
 
   derived_type &operator=(const type &val) {
-    write(val);
+    this->write(val);
     return static_cast<derived_type &>(*this);
   }
 };
@@ -215,7 +215,7 @@ public:
 
   // i dont understand why i need this here...
   global_ptr<type, x64> &operator=(const type &val) {
-    write(val);
+    this->write(val);
     return *this;
   }
 };


### PR DESCRIPTION
the clang-format change is because the doxygen comments were being reformatted and line breaks weren't kept